### PR TITLE
Fix authentication call order and adjust OAuth scopes

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -16,7 +16,6 @@ if (missingEnvVars.length > 0 && process.env.NODE_ENV !== 'test') {
 
 // Set scopes
 const SCOPES = [
-  'https://www.googleapis.com/auth/calendar',
   'https://www.googleapis.com/auth/calendar.events',
 ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,8 +25,8 @@ process.on('uncaughtException', (error: Error) => {
 // Server startup
 async function main() {
   try {
-    await mcpServer.start();
     await oauthAuth.getAuthenticatedClient();
+    await mcpServer.start();
   } catch (error) {
     logger.error(`Failed to start server: ${error}`);
     process.exit(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,10 +25,8 @@ process.on('uncaughtException', (error: Error) => {
 // Server startup
 async function main() {
   try {
-    // Initialize authentication before starting the server
-    // Always assume we're running under MCP inspector
-    await oauthAuth.getAuthenticatedClient();
     await mcpServer.start();
+    await oauthAuth.getAuthenticatedClient();
   } catch (error) {
     logger.error(`Failed to start server: ${error}`);
     process.exit(1);


### PR DESCRIPTION
Reordered the `getAuthenticatedClient` call to ensure proper initialization before starting the server. Removed unnecessary OAuth scope for calendar access to streamline permissions.