### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,10 @@ npm run build
 npm start
 ```
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/takumi0706-google-calendar-mcp).
+
 ## Production Deployment
 
 For production use, the server requires valid Google OAuth credentials. The server will fail to start without proper credentials, ensuring security compliance.


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/takumi0706-google-calendar-mcp).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deployment instructions for users to access the application via the hosted Fronteir AI deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->